### PR TITLE
ci: add phpstan to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ install:
 script:
   - composer install
   - composer test
+  - composer stan

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "lint": "php-cs-fixer fix ./src --rules=@PSR2 --diff --dry-run",
         "lint-fix": "php-cs-fixer fix ./src --rules=@PSR2",
         "test": "vendor/bin/phpunit",
-        "stan": "vendor/bin/phpstan analyse src --level 7",
+        "stan": "vendor/bin/phpstan analyse",
         "test-coverage": "vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml",
         "test-coverage-html": "vendor/bin/phpunit --coverage-text --coverage-html=build"
     }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,5 @@
+parameters:
+    level: max
+    paths:
+        - ./src
+    checkMissingIterableValueType: false

--- a/src/Exception/HttpClientException.php
+++ b/src/Exception/HttpClientException.php
@@ -28,7 +28,7 @@ final class HttpClientException extends \RuntimeException implements CardMarketE
         parent::__construct($message, $code);
     }
 
-    public static function badRequest(ResponseInterface $response)
+    public static function badRequest(ResponseInterface $response): self
     {
         $body = $response->getContent(false);
 
@@ -44,22 +44,22 @@ final class HttpClientException extends \RuntimeException implements CardMarketE
         return new self($message, 400, $response);
     }
 
-    public static function unauthorized(ResponseInterface $response)
+    public static function unauthorized(ResponseInterface $response): self
     {
         return new self('Authentication or authorization fails during your request, e.g. your Authorization (signature) is not correct.', 401, $response);
     }
 
-    public static function forbidden(ResponseInterface $response)
+    public static function forbidden(ResponseInterface $response): self
     {
         return new self('You try to access a forbidden resource. Check your Authorization Header.', 403, $response);
     }
 
-    public static function notFound(ResponseInterface $response)
+    public static function notFound(ResponseInterface $response): self
     {
         return new self('The endpoint you have tried to access does not exist.', 404, $response);
     }
 
-    public static function tooManyRequests(ResponseInterface $response)
+    public static function tooManyRequests(ResponseInterface $response): self
     {
         return new self('You have reached your maximum calls per day.', 429, $response);
     }

--- a/src/Helper/CsvStockFileHelper.php
+++ b/src/Helper/CsvStockFileHelper.php
@@ -12,6 +12,9 @@ namespace Mamoot\CardMarket\Helper;
  */
 final class CsvStockFileHelper
 {
+    /**
+     * @var string
+     */
     private $stockFileContent;
 
     public function __construct(string $stockFileContent)


### PR DESCRIPTION
Also fixing phpstan errors.

As seen together for the moment we could disable `checkMissingIterableValueType`